### PR TITLE
fix: don't let container scratch-dir cleanup discard a completed task

### DIFF
--- a/conda_forge_feedstock_ops/__main__.py
+++ b/conda_forge_feedstock_ops/__main__.py
@@ -72,11 +72,13 @@ def _get_existing_feedstock_node_attrs(existing_feedstock_node_attrs):
 
 def _run_bot_task(func, *, log_level, existing_feedstock_node_attrs, **kwargs):
     with (
-        tempfile.TemporaryDirectory() as tmpdir_cbld,
+        tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir_cbld,
         _setenv("CONDA_BLD_PATH", os.path.join(tmpdir_cbld, "conda-bld")),
-        tempfile.TemporaryDirectory() as tmpdir_cache,
+        tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir_cache,
         _setenv("XDG_CACHE_HOME", tmpdir_cache),
-        tempfile.TemporaryDirectory() as tmpdir_conda_pkgs_dirs,
+        tempfile.TemporaryDirectory(
+            ignore_cleanup_errors=True
+        ) as tmpdir_conda_pkgs_dirs,
         _setenv("CONDA_PKGS_DIRS", tmpdir_conda_pkgs_dirs),
     ):
         os.makedirs(os.path.join(tmpdir_cbld, "conda-bld"), exist_ok=True)
@@ -90,7 +92,7 @@ def _run_bot_task(func, *, log_level, existing_feedstock_node_attrs, **kwargs):
         try:
             with (
                 redirect_stdout(sys.stderr),
-                tempfile.TemporaryDirectory() as tmpdir,
+                tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir,
                 pushd(tmpdir),
             ):
                 # logger call needs to be here so it gets the changed stdout/stderr
@@ -155,7 +157,7 @@ def _rerender_feedstock(*, exclusive_config_file, timeout):
 
     logger = logging.getLogger("conda_forge_feedstock_ops.container")
 
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
         input_fs_dir = glob.glob("/cf_feedstock_ops_dir/*-feedstock")
         assert len(input_fs_dir) == 1, f"expected one feedstock, got {input_fs_dir}"
         input_fs_dir = input_fs_dir[0]
@@ -276,7 +278,7 @@ def _parse_package_and_feedstock_names():
 
     logger = logging.getLogger("conda_forge_feedstock_ops.container")
 
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
         input_fs_dir = glob.glob("/cf_feedstock_ops_dir/*-feedstock")
         assert len(input_fs_dir) == 1, f"expected one feedstock, got {input_fs_dir}"
         input_fs_dir = input_fs_dir[0]
@@ -314,7 +316,7 @@ def _lint():
 
     logger = logging.getLogger("conda_forge_feedstock_ops.container")
 
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
         input_fs_dir = "/cf_feedstock_ops_dir"
         logger.debug(
             "input container feedstock dir %s: %s",


### PR DESCRIPTION
Fixes #88

## Summary

A rerender that **succeeded** gets reported to the maintainer as `Rerendering failed` and its patch discarded, when cleanup of the container's scratch directories raises `OSError: [Errno 39] Directory not empty`.

The operations return out of a `with tempfile.TemporaryDirectory()` block, so a teardown failure propagates in place of the result and `run_container_operation()` raises instead of returning `ret["data"]`. These directories are scratch space in a container that is about to exit, on a tmpfs discarded with it, so a cleanup failure carries no information and should not be able to fail a completed task.

This passes `ignore_cleanup_errors=True` to all seven `tempfile.TemporaryDirectory()` call sites in `__main__.py` — the set enumerated in #88's suggestion 2.

## Currently blocked RISC-V migration PRs
https://github.com/conda-forge/datefudge-feedstock/pull/11
https://github.com/conda-forge/dovi_tool-feedstock/pull/10


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
